### PR TITLE
Add AUTOVERSION_FOO=1.2.3 to override 'foo' version

### DIFF
--- a/__autoversion__.py
+++ b/__autoversion__.py
@@ -91,6 +91,11 @@ def version_from_frame(frame):
 
     module_name = module.__name__
 
+    variable = "AUTOVERSION_{}".format(module_name.upper())
+    override = os.environ.get(variable, None)
+    if override is not None:
+        return override
+
     while True:
         try:
             get_distribution(module_name)


### PR DESCRIPTION
This is useful during testing when there may be a checkout of the
repository without a copy of the repository in the correct state.